### PR TITLE
Fix invalid OBO namespaces declared in `zeco.owl` and `zeco.obo`

### DIFF
--- a/zeco.obo
+++ b/zeco.obo
@@ -888,14 +888,14 @@ is_a: ZECO:0000253 ! gavage
 [Typedef]
 id: has_component
 name: has_component
-namespace: zebrafish experimental conditions ontology
+namespace: zebrafish_experimental_conditions_ontology
 xref: RO:0002211
 creation_date: 2014-03-07T11:34:22Z
 
 [Typedef]
 id: has_part
 name: has_part
-namespace: zebrafish experimental conditions ontology
+namespace: zebrafish_experimental_conditions_ontology
 xref: BFO:0000051
 is_transitive: true
 creation_date: 2014-03-07T11:32:23Z
@@ -903,7 +903,7 @@ creation_date: 2014-03-07T11:32:23Z
 [Typedef]
 id: part_of
 name: part_of
-namespace: zebrafish experimental conditions ontology 
+namespace: zebrafish_experimental_conditions_ontology
 xref: BFO:0000050
 is_transitive: true
 

--- a/zeco.owl
+++ b/zeco.owl
@@ -184,7 +184,7 @@
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/BFO_0000050">
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BFO:0000050</oboInOwl:hasDbXref>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">zebrafish experimental conditions ontology </oboInOwl:hasOBONamespace>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">zebrafish_experimental_conditions_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">part_of</oboInOwl:id>
         <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">part_of</oboInOwl:shorthand>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">part_of</rdfs:label>
@@ -198,7 +198,7 @@
         <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#TransitiveProperty"/>
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2014-03-07T11:32:23Z</oboInOwl:creation_date>
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">BFO:0000051</oboInOwl:hasDbXref>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">zebrafish experimental conditions ontology</oboInOwl:hasOBONamespace>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">zebrafish_experimental_conditions_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_part</oboInOwl:id>
         <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_part</oboInOwl:shorthand>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_part</rdfs:label>
@@ -211,7 +211,7 @@
     <owl:ObjectProperty rdf:about="http://purl.obolibrary.org/obo/RO_0002211">
         <oboInOwl:creation_date rdf:datatype="http://www.w3.org/2001/XMLSchema#string">2014-03-07T11:34:22Z</oboInOwl:creation_date>
         <oboInOwl:hasDbXref rdf:datatype="http://www.w3.org/2001/XMLSchema#string">RO:0002211</oboInOwl:hasDbXref>
-        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">zebrafish experimental conditions ontology</oboInOwl:hasOBONamespace>
+        <oboInOwl:hasOBONamespace rdf:datatype="http://www.w3.org/2001/XMLSchema#string">zebrafish_experimental_conditions_ontology</oboInOwl:hasOBONamespace>
         <oboInOwl:id rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_component</oboInOwl:id>
         <oboInOwl:shorthand rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_component</oboInOwl:shorthand>
         <rdfs:label rdf:datatype="http://www.w3.org/2001/XMLSchema#string">has_component</rdfs:label>


### PR DESCRIPTION
Hi!

This PR fixes invalid OBO namespaces being declared in the `[Typedef]` frames in `zeco.obo`. OBO namespaces cannot contain whitespaces. This is the only syntax error in ZECO that prevents it from being compliant with the [OBO Format 1.4](http://owlcollab.github.io/oboformat/doc/obo-syntax.html).